### PR TITLE
Fix start script path and logging

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,20 +1,29 @@
 #!/bin/bash
+set -euo pipefail
 
 # Activate python virtual environment
+echo "Activating Python virtual environment..."
 test -d backend/venv || python3 -m venv backend/venv
 source backend/venv/bin/activate
-pip install -r backend/requirements.txt >/dev/null 2>&1
+
+# Install Python dependencies
+echo "Installing Python dependencies..."
+pip install -r backend/requirements.txt
 
 # Install Node packages if node_modules doesn't exist
+echo "Installing Node packages..."
 if [ ! -d frontend/node_modules ]; then
-  cd frontend && npm install >/dev/null 2>&1 && cd ..
+  (cd frontend && npm install)
 fi
 
 # Run backend and frontend
-cd backend && uvicorn app.main:app --reload &
+echo "Starting backend..."
+(cd backend && uvicorn app.main:app --reload) &
 BACK_PID=$!
-cd ../frontend && npm run dev &
+
+echo "Starting frontend..."
+(cd frontend && npm run dev) &
 FRONT_PID=$!
 
-trap "kill $BACK_PID $FRONT_PID" EXIT
+trap 'echo "Stopping..."; kill $BACK_PID $FRONT_PID' EXIT
 wait


### PR DESCRIPTION
## Summary
- show installation logs in `start.sh`
- keep current directory while starting backend and frontend
- correct path to `frontend` directory

## Testing
- `bash -n start.sh`
- `./start.sh` *(fails: Could not find a version that satisfies the requirement fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_684970c9d0cc8326ba5a360f07bc1050