### PR TITLE
Fix pip install error in setup script

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -8,6 +8,7 @@ source backend/venv/bin/activate
 
 # Install Python dependencies
 echo "Installing Python dependencies..."
+pip install --upgrade pip
 pip install -r backend/requirements.txt
 
 # Install Node packages if node_modules doesn't exist


### PR DESCRIPTION
## Summary
- upgrade pip before installing Python dependencies in `start.sh`

This ensures newer packages like `pydantic-core` can install correctly even on
systems where the default `pip` is outdated.

## Testing
- `bash -n start.sh`

------
https://chatgpt.com/codex/tasks/task_e_6849733c95148326b61487c319bcb165