### PR TITLE
Fix environment loading for backend

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,10 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from dotenv import load_dotenv
+
+# Load environment variables from .env if present before other imports
+load_dotenv()
+
 from .interfaces.router import router
 
 app = FastAPI(title="Gemini Tagging API")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,3 +3,4 @@ uvicorn
 python-multipart
 pydantic
 google-generativeai
+python-dotenv

--- a/start.sh
+++ b/start.sh
@@ -6,6 +6,13 @@ echo "Activating Python virtual environment..."
 test -d backend/venv || python3 -m venv backend/venv
 source backend/venv/bin/activate
 
+# Load environment variables for the backend if available
+if [ -f backend/.env ]; then
+  set -a
+  source backend/.env
+  set +a
+fi
+
 # Install Python dependencies
 echo "Installing Python dependencies..."
 pip install --upgrade pip


### PR DESCRIPTION
## Summary
- ensure backend .env is loaded when running the project
- auto load `.env` in FastAPI app
- add `python-dotenv` dependency

## Testing
- `pytest -q`
- `python -m py_compile backend/app/main.py backend/app/infrastructure/gemini_service.py`


------
https://chatgpt.com/codex/tasks/task_e_684c17c0dcd08326905725d91856b648