### PR TITLE
Fix gemini library check

### DIFF
--- a/backend/app/infrastructure/gemini_service.py
+++ b/backend/app/infrastructure/gemini_service.py
@@ -4,6 +4,13 @@ import os
 import asyncio
 import google.generativeai as genai
 
+if not hasattr(genai, "GenerativeModel"):
+    raise ImportError(
+        "google-generativeai package is outdated."
+        " Please install version 0.3.0 or newer."
+    )
+
+
 class GeminiService:
     """Gemini API と通信する役割を持つサービス。"""
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,5 +2,5 @@ fastapi
 uvicorn
 python-multipart
 pydantic
-google-generativeai
+google-generativeai>=0.3.0
 python-dotenv


### PR DESCRIPTION
## Summary
- guard against outdated `google-generativeai` module
- require `google-generativeai>=0.3.0`

## Testing
- `ruff check backend/app/infrastructure/gemini_service.py`
- `black backend/app/infrastructure/gemini_service.py --check`

------
https://chatgpt.com/codex/tasks/task_e_684c1bc271908326afe123bdfaf1495f